### PR TITLE
[feat] 검색 화면에 필요한 API 연동/런처 fragment변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,6 +23,7 @@ android {
 
         buildConfigField "String", "RANKING_API_KEY", properties['ranking_api_key']
         buildConfigField "String", "KRX_API_KEY", properties['krx_api_key']
+        buildConfigField "String", "DETAIL_API_KEY", properties['detail_api_key']
     }
 
     buildTypes {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,6 +22,7 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField "String", "RANKING_API_KEY", properties['ranking_api_key']
+        buildConfigField "String", "KRX_API_KEY", properties['krx_api_key']
     }
 
     buildTypes {

--- a/app/src/main/java/com/hamcoding/berryy/MainActivity.kt
+++ b/app/src/main/java/com/hamcoding/berryy/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.hamcoding.berryy.data.source.DetailApiClient
 import com.hamcoding.berryy.data.source.RankApiClient
 import com.hamcoding.berryy.databinding.ActivityMainBinding
 import kotlinx.coroutines.coroutineScope
@@ -30,6 +31,7 @@ class MainActivity : AppCompatActivity() {
         navController.addOnDestinationChangedListener { _, destination, _ ->
             when (destination.id) {
                 R.id.onBoardingFragment -> navView.visibility = View.GONE
+                R.id.launcherFragment -> navView.visibility = View.GONE
                 else -> navView.visibility = View.VISIBLE
             }
         }

--- a/app/src/main/java/com/hamcoding/berryy/data/model/DetailDTO.kt
+++ b/app/src/main/java/com/hamcoding/berryy/data/model/DetailDTO.kt
@@ -1,0 +1,34 @@
+package com.hamcoding.berryy.data.model
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class DetailResponse(
+    val response: DividendResponse
+) : Serializable
+
+data class DividendResponse(
+    val header: DividendHeader,
+    val body: DividendBody,
+) : Serializable
+
+data class DividendBody(
+    val items: DividendItemList
+) : Serializable
+
+data class DividendItemList(
+    val item: List<DividendItem>
+) : Serializable
+
+data class DividendItem(
+    @SerializedName("crno") val companyCode: String,
+    @SerializedName("stckIssuCmpyNm") val companyName: String,
+    @SerializedName("dvdnBasDt") val baseDate: String,
+    @SerializedName("cashDvdnPayDt") val payDate: String,
+    @SerializedName("stckGenrDvdnAmt") val amount: String,
+)
+
+data class DividendHeader(
+    val resultCode: String,
+    val resultMsg: String,
+) : Serializable

--- a/app/src/main/java/com/hamcoding/berryy/data/model/KrxDTO.kt
+++ b/app/src/main/java/com/hamcoding/berryy/data/model/KrxDTO.kt
@@ -1,0 +1,31 @@
+package com.hamcoding.berryy.data.model
+
+import com.google.gson.annotations.SerializedName
+import java.io.Serializable
+
+data class SearchResponse(
+    val response: KrxResponse,
+)
+
+data class KrxResponse(
+    val header: KrxHeader,
+    val body: KrxBody,
+) : Serializable
+
+data class KrxBody(
+    val items: KrxItemList
+) : Serializable
+
+data class KrxItemList(
+    val item: List<KrxItem>
+)
+
+data class KrxItem(
+    @SerializedName("itmsNm") val name: String,
+    @SerializedName("crno") val companyCode: String,
+) : Serializable
+
+data class KrxHeader(
+    val resultCode: String,
+    val resultMsg: String,
+) : Serializable

--- a/app/src/main/java/com/hamcoding/berryy/data/source/DetailApiClient.kt
+++ b/app/src/main/java/com/hamcoding/berryy/data/source/DetailApiClient.kt
@@ -1,8 +1,7 @@
 package com.hamcoding.berryy.data.source
 
 import com.hamcoding.berryy.BuildConfig
-import com.hamcoding.berryy.data.model.KrxResponse
-import com.hamcoding.berryy.data.model.SearchResponse
+import com.hamcoding.berryy.data.model.DetailResponse
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -10,21 +9,21 @@ import retrofit2.converter.gson.GsonConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-interface KrxApiClient {
+interface DetailApiClient {
 
-    @GET("getItemInfo")
-    suspend fun getSearchResult(
-        @Query("itmsNm") name: String,
-        @Query("serviceKey") apiKey: String = BuildConfig.KRX_API_KEY,
-        @Query("resultType") resultType: String = "json"
-    ): SearchResponse
+    @GET("getDiviInfo")
+    suspend fun getDetailList(
+        @Query("crno") companyCode: String,
+        @Query("serviceKey") apiKey: String = BuildConfig.DETAIL_API_KEY,
+        @Query("resultType") resultType: String = "JSON",
+    ) : DetailResponse
 
     companion object {
 
         private const val BASE_URL =
-            "https://apis.data.go.kr/1160100/service/GetKrxListedInfoService/"
+            "http://apis.data.go.kr/1160100/service/GetStocDiviInfoService/"
 
-        fun create(): KrxApiClient {
+        fun create(): DetailApiClient {
             val logger = HttpLoggingInterceptor().apply {
                 level = HttpLoggingInterceptor.Level.BODY
             }
@@ -38,7 +37,7 @@ interface KrxApiClient {
                 .client(client)
                 .addConverterFactory(GsonConverterFactory.create())
                 .build()
-                .create(KrxApiClient::class.java)
+                .create(DetailApiClient::class.java)
 
         }
     }

--- a/app/src/main/java/com/hamcoding/berryy/data/source/KrxApiClient.kt
+++ b/app/src/main/java/com/hamcoding/berryy/data/source/KrxApiClient.kt
@@ -1,0 +1,45 @@
+package com.hamcoding.berryy.data.source
+
+import com.hamcoding.berryy.BuildConfig
+import com.hamcoding.berryy.data.model.KrxResponse
+import com.hamcoding.berryy.data.model.SearchResponse
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface KrxApiClient {
+
+    @GET("getItemInfo")
+    suspend fun getKrxStockList(
+        @Query("itmsNm") name: String,
+        @Query("serviceKey") apiKey: String = BuildConfig.KRX_API_KEY,
+        @Query("resultType") resultType: String = "json"
+    ): SearchResponse
+
+    companion object {
+
+        private const val BASE_URL =
+            "https://apis.data.go.kr/1160100/service/GetKrxListedInfoService/"
+
+        fun create(): KrxApiClient {
+            val logger = HttpLoggingInterceptor().apply {
+                level = HttpLoggingInterceptor.Level.BODY
+            }
+
+            val client = OkHttpClient.Builder()
+                .addInterceptor(logger)
+                .build()
+
+            return Retrofit.Builder()
+                .baseUrl(BASE_URL)
+                .client(client)
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(KrxApiClient::class.java)
+
+        }
+    }
+}

--- a/app/src/main/java/com/hamcoding/berryy/data/source/RankApiClient.kt
+++ b/app/src/main/java/com/hamcoding/berryy/data/source/RankApiClient.kt
@@ -4,7 +4,6 @@ import com.hamcoding.berryy.BuildConfig
 import com.hamcoding.berryy.data.model.RankResponse
 import com.tickaroo.tikxml.TikXml
 import com.tickaroo.tikxml.retrofit.TikXmlConverterFactory
-import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit

--- a/app/src/main/java/com/hamcoding/berryy/ui/LauncherFragment.kt
+++ b/app/src/main/java/com/hamcoding/berryy/ui/LauncherFragment.kt
@@ -7,29 +7,42 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.navigation.fragment.findNavController
 import com.hamcoding.berryy.R
+import com.hamcoding.berryy.databinding.FragmentLauncherBinding
 
 class LauncherFragment : Fragment() {
+
+    private var _binding: FragmentLauncherBinding? = null
+    private val binding get() = _binding!!
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
     }
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_launcher, container, false)
+    ): View {
+        _binding = FragmentLauncherBinding.inflate(inflater, container, false)
+        return binding.root
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        val isOnBoarding = true
-        if (isOnBoarding) {
+//        val isOnBoarding = true
+//        if (isOnBoarding) {
+//            findNavController().navigate(R.id.action_launcherFragment_to_onBoardingFragment)
+//        } else {
+//            findNavController().navigate(R.id.action_launcherFragment_to_navigation_home)
+//        }
+        binding.btnOnboarding.setOnClickListener {
             findNavController().navigate(R.id.action_launcherFragment_to_onBoardingFragment)
-        } else {
-            findNavController().navigate(R.id.action_launcherFragment_to_navigation_home)
         }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
     }
 
 }

--- a/app/src/main/res/layout/fragment_launcher.xml
+++ b/app/src/main/res/layout/fragment_launcher.xml
@@ -1,14 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".ui.LauncherFragment">
 
-    <!-- TODO: Update blank fragment layout -->
-    <TextView
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        tools:context=".ui.LauncherFragment">
 
-</FrameLayout>
+        <Button
+            android:id="@+id/btnOnboarding"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="온보딩 화면 시작하기"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>


### PR DESCRIPTION
# Summary
1. KRX 검색 API 연동
2. 배당 정보 API 연동
3. launcher fragment 수정 -> 매번 온보딩 화면에 진입하면 API 요청이 이루어지므로 디버깅할 때 부담이 됨. 온보딩 화면 런처 fragment에서 접속하도록 수정 

# Screenshot
![image](https://user-images.githubusercontent.com/102295347/222959437-97c508d2-3771-44b5-a53d-b533f2ec23ec.png)
